### PR TITLE
Specifying Path to Composite Entity Patterns File in Config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,44 @@ pipeline:
 - name: "rasa_composite_entities.CompositeEntityExtractor"
 ```
 
+An optional configuration variable `composite_entity_patterns` can be used to specify the filename where the composite entity patterns are defined:
+
+```yaml
+language: "en_core_web_md"
+
+pipeline:
+- name: "SpacyNLP"
+- name: "SpacyTokenizer"
+- name: "SpacyFeaturizer"
+- name: "CRFEntityExtractor"
+- name: "SklearnIntentClassifier"
+- name: "rasa_composite_entities.CompositeEntityExtractor"
+  composite_entity_patterns: "path/to/composite_entity_patterns.json"
+```
+
+`composite_entity_patterns` can be defined as the path to the parent training file:
+
+```json
+{
+    "rasa_nlu_data": {
+        "composite_entities": [],
+        "common_examples": [],
+        "regex_features" : [],
+        "lookup_tables"  : [],
+        "entity_synonyms": []
+    }
+}
+```
+
+or in as the path to a stand-alone json file:
+
+```json
+{
+    "composite_entities": []
+}
+```
+
+
 ## Usage
 
 Simply add another entry to your training file (in JSON format) defining

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ pipeline:
 - name: "rasa_composite_entities.CompositeEntityExtractor"
 ```
 
-
-
-
 ## Usage
 
 Simply add another entry to your training file (in JSON format) defining

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ pipeline:
 - name: "CRFEntityExtractor"
 - name: "SklearnIntentClassifier"
 - name: "rasa_composite_entities.CompositeEntityExtractor"
-  composite_entity_path: "path/to/composite_entity_patterns.json"
+  composite_patterns_path: "path/to/composite_entity_patterns.json"
 ```
 
-`composite_entity_patterns` can be defined as the path to the parent training file:
+`composite_patterns_path` can be defined as the path to the parent training file:
+
+`nlu.json`
 
 ```json
 {
@@ -107,6 +109,8 @@ pipeline:
 ```
 
 or in as the path to a stand-alone json file:
+
+`composite_entities.json`
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -31,42 +31,7 @@ pipeline:
 - name: "rasa_composite_entities.CompositeEntityExtractor"
 ```
 
-An optional configuration variable `composite_entity_patterns` can be used to specify the filename where the composite entity patterns are defined:
 
-```yaml
-language: "en_core_web_md"
-
-pipeline:
-- name: "SpacyNLP"
-- name: "SpacyTokenizer"
-- name: "SpacyFeaturizer"
-- name: "CRFEntityExtractor"
-- name: "SklearnIntentClassifier"
-- name: "rasa_composite_entities.CompositeEntityExtractor"
-  composite_entity_patterns: "path/to/composite_entity_patterns.json"
-```
-
-`composite_entity_patterns` can be defined as the path to the parent training file:
-
-```json
-{
-    "rasa_nlu_data": {
-        "composite_entities": [],
-        "common_examples": [],
-        "regex_features" : [],
-        "lookup_tables"  : [],
-        "entity_synonyms": []
-    }
-}
-```
-
-or in as the path to a stand-alone json file:
-
-```json
-{
-    "composite_entities": []
-}
-```
 
 
 ## Usage
@@ -111,6 +76,45 @@ Patterns are regular expressions! You can use patterns like
 to match different variations of entity combinations. Be aware that you may
 need to properly escape your regexes to produce valid JSON files (in case of
 this example, you have to escape the backslashes with another backslash).
+
+An optional configuration variable `composite_patterns_path` can be used to specify the filename where the composite entity patterns are defined:
+
+```yaml
+language: "en_core_web_md"
+
+pipeline:
+- name: "SpacyNLP"
+- name: "SpacyTokenizer"
+- name: "SpacyFeaturizer"
+- name: "CRFEntityExtractor"
+- name: "SklearnIntentClassifier"
+- name: "rasa_composite_entities.CompositeEntityExtractor"
+  composite_entity_path: "path/to/composite_entity_patterns.json"
+```
+
+`composite_entity_patterns` can be defined as the path to the parent training file:
+
+```json
+{
+    "rasa_nlu_data": {
+        "composite_entities": [],
+        "common_examples": [],
+        "regex_features" : [],
+        "lookup_tables"  : [],
+        "entity_synonyms": []
+    }
+}
+```
+
+or in as the path to a stand-alone json file:
+
+```json
+{
+    "composite_entities": []
+}
+```
+
+__Note:__ Either option works, but giving a path to the external file is preferred. 
 
 ## Explanation
 

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -135,7 +135,7 @@ class CompositeEntityExtractor(EntityExtractor):
             write_json_to_file(
                 composite_entities_file,
                 self.composite_entities,
-                separators=(",", ": ")
+                separators=(",", ": "),
             )
 
     @classmethod
@@ -253,5 +253,5 @@ class CompositeEntityExtractor(EntityExtractor):
         message.set(
             "entities",
             entities + processed_composite_entities,
-            add_to_output=True
+            add_to_output=True,
         )

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -88,7 +88,8 @@ class CompositeEntityExtractor(EntityExtractor):
                     files = self._get_train_files_http()
                 except:
                     warnings.warn(
-                        "The CompositeEntityExtractor could not load the train file."
+                        "The CompositeEntityExtractor could not load "
+                        "the train file."
                     )
                     return [] 
         composite_entities = []
@@ -132,8 +133,8 @@ class CompositeEntityExtractor(EntityExtractor):
                 dir_name, COMPOSITE_ENTITIES_FILE_NAME
             )
             write_json_to_file(
-                composite_entities_file, 
-                self.composite_entities, 
+                composite_entities_file,
+                self.composite_entities,
                 separators=(",", ": ")
             )
 
@@ -245,12 +246,12 @@ class CompositeEntityExtractor(EntityExtractor):
             )
 
         entities = [
-            entity 
-            for i, entity in enumerate(entities) 
+            entity
+            for i, entity in enumerate(entities)
             if i not in used_entity_indices
         ]
         message.set(
-            "entities", 
-            entities + processed_composite_entities, 
+            "entities",
+            entities + processed_composite_entities,
             add_to_output=True
         )

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -13,7 +13,7 @@ from rasa.utils.io import list_files, read_json_file
 
 COMPOSITE_ENTITIES_FILE_NAME = "composite_entities.json"
 ENTITY_PREFIX = "@"
-RASA_NLU = "rasa_nlu"
+RASA_NLU = "rasa"
 
 
 class CompositeEntityExtractor(EntityExtractor):
@@ -37,6 +37,8 @@ class CompositeEntityExtractor(EntityExtractor):
         it will be in the "data" argument.
         """
         cmdline_args = create_argument_parser().parse_args()
+        if not cmdline_args.__contains__("nlu"):
+            cmdline_args.nlu = 'data/generated/training.json'
         try:
             files = list_files(cmdline_args.nlu)
         except AttributeError:

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -21,6 +21,7 @@ from rasa.nlu.utils import write_json_to_file
 from rasa.utils.io import list_files, read_json_file
 
 COMPOSITE_ENTITIES_FILE_NAME = "composite_entities.json"
+COMPOSITE_PATTERNS_KEY = "composite_entity_patterns"
 ENTITY_PREFIX = "@"
 RASA_NLU = "rasa_nlu"
 
@@ -78,12 +79,12 @@ class CompositeEntityExtractor(EntityExtractor):
         """
         try:
             files = [self.component_config[COMPOSITE_PATTERNS_KEY]]
-            warnings.warn("No composite entity patterns path set in config.yml")
         except:
+            warnings.warn("No composite entity patterns path set in config.yml")
             try:
                 files = self._get_train_files_cmd()
-                warnings.warn("No train file specified in cli command.")
             except:
+                warnings.warn("No train file specified in cli command.")
                 try:
                     files = self._get_train_files_http()
                 except:

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -51,12 +51,7 @@ class CompositeEntityExtractor(EntityExtractor):
             files = list_files(cmdline_args.nlu)
         except AttributeError:
             files = list(get_core_nlu_files(cmdline_args.data)[1])
-<<<<<<< HEAD
-        result = [file for file in files if guess_format(file) == RASA_NLU]
-        return result
-=======
-        return [file for file in files if _guess_format(file) == RASA_NLU]
->>>>>>> 7187a735f38df342d7c57bbfd8401d7ef7fcec84
+        return [file for file in files if guess_format(file) == RASA_NLU]
 
     @staticmethod
     def _get_train_files_http():

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -51,8 +51,7 @@ class CompositeEntityExtractor(EntityExtractor):
             files = list_files(cmdline_args.nlu)
         except AttributeError:
             files = list(get_core_nlu_files(cmdline_args.data)[1])
-        result = [file for file in files if _guess_format(file) == RASA_NLU]
-        return result
+        return [file for file in files if _guess_format(file) == RASA_NLU]
 
     @staticmethod
     def _get_train_files_http():


### PR DESCRIPTION
Related to #9. 

I added a section in the readme explaining how to use this new configuration option - let me know if there are any questions. I tested this with relative and absolute paths to the training file. If one were to run `rasa train` in the rasa directory, a relative path is fine, however invoking `rasa train` from another location requires the composite entity patterns path to be absolute. 

I was not able to test out the existing cmd line or http routes of loading the composite entity file. If someone with this setup can test this, I would be grateful. If not, I can try to set something up in the next day or two. 

I'm happy to make any further changes!

(Also, this might be minor and I do not think I included it in this PR: I found that using a `value` field that is the same as the `contained_entities` field works nicer if passing the nlu object to a typed language because as far as I've found all other entity objects have a `value` field). 