### PR TITLE
Support for Multi-level Hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 .mypy_cache/
 
 .DS_Store
+
+#Pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,31 @@ to match different variations of entity combinations. Be aware that you may
 need to properly escape your regexes to produce valid JSON files (in case of
 this example, you have to escape the backslashes with another backslash).
 
+#### Multiple Hierarchy Levels
+
+Now you can use multiple hierarchies by using the `CompositeEntityExtractor` multiple times in your configuration 
+pipeline. Just provide an additional parameter `composite_entities_file` which should be unique for each instance of the 
+`CompositeEntityExtractor` component in the pipeline.
+
+```yaml
+language: "en_core_web_md"
+
+pipeline:
+- name: "SpacyNLP"
+- name: "SpacyTokenizer"
+- name: "SpacyFeaturizer"
+- name: "CRFEntityExtractor"
+- name: "SklearnIntentClassifier"
+- name: "rasa_composite_entities.CompositeEntityExtractor"
+  composite_patterns_path: "path/to/composite_entity_patterns_level_1.json"
+  composite_entities_file: "hierarchy_level_1.json"
+- name: "rasa_composite_entities.CompositeEntityExtractor"
+  composite_patterns_path: "path/to/composite_entity_patterns_level_2.json"
+  composite_entities_file: "hierarchy_level_2.json"
+```
+Please note that the patterns in the second level of hierarchy should be the combination of the entities detected in the 
+previous level or even including other lower level entities which may not be a part of any of the previous patterns.
+
 ## Explanation
 
 Composite entities act as containers that group several entities into logical

--- a/rasa_composite_entities/composite_entity_extractor.py
+++ b/rasa_composite_entities/composite_entity_extractor.py
@@ -11,7 +11,8 @@ from rasa.nlu.training_data.loading import guess_format
 from rasa.nlu.utils import write_json_to_file
 from rasa.utils.io import list_files, read_json_file
 
-COMPOSITE_ENTITIES_FILE_NAME = "composite_entities.json"
+COMPOSITE_ENTITIES_DEFAULT_FILE_NAME = "composite_entities.json"
+COMPOSITE_ENTITIES_FILE = "composite_entities_file"
 COMPOSITE_PATTERNS_PATH = "composite_patterns_path"
 ENTITY_PREFIX = "@"
 RASA_NLU = "rasa_nlu"
@@ -122,6 +123,7 @@ class CompositeEntityExtractor(EntityExtractor):
 
     def persist(self, file_name, dir_name):
         if self.composite_entities:
+            COMPOSITE_ENTITIES_FILE_NAME = self.component_config.get(COMPOSITE_ENTITIES_FILE, COMPOSITE_ENTITIES_DEFAULT_FILE_NAME)
             composite_entities_file = os.path.join(
                 dir_name, COMPOSITE_ENTITIES_FILE_NAME
             )
@@ -141,7 +143,7 @@ class CompositeEntityExtractor(EntityExtractor):
         **kwargs
     ):
         file_name = component_meta.get(
-            "composite_entities_file", COMPOSITE_ENTITIES_FILE_NAME
+            COMPOSITE_ENTITIES_FILE, COMPOSITE_ENTITIES_DEFAULT_FILE_NAME
         )
         composite_entities_file = os.path.join(model_dir, file_name)
         if os.path.isfile(composite_entities_file):


### PR DESCRIPTION
Currently the `CompositeEntityExtractor` can be used multiple times in the rasa configuration pipeline but only the patterns in the last instance are saved because the metadata for all others get overwritten in the default `composite_entities.json` file. We can overcome this by taking in `composite_entities_file` from the configuration(.yml) as the file name to store the metadata for each instance of the `CompositeEntityExtractor`component. Alternatively, we can generate a random file name each time the component is initialised.